### PR TITLE
Restore compile time codegen for OrleansRuntime and OrleansProviders

### DIFF
--- a/src/OrleansProviders/OrleansProviders.csproj
+++ b/src/OrleansProviders/OrleansProviders.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Streams\Common\EventSequenceToken.cs" />
     <Compile Include="ProviderErrorCode.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\orleans.codegen.cs" />
     <Compile Include="..\Build\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
@@ -79,4 +80,25 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- Begin Orleans: Without these lines the project won't build properly -->
+  <PropertyGroup>
+    <OrleansProjectType>Server</OrleansProjectType>
+  </PropertyGroup>
+  <!-- Set path to ClientGenerator.exe -->
+  <Choose>
+    <When Condition="'$(builduri)' != ''">
+      <PropertyGroup>
+        <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
+  <!--End Orleans -->
 </Project>

--- a/src/OrleansRuntime/OrleansRuntime.csproj
+++ b/src/OrleansRuntime/OrleansRuntime.csproj
@@ -175,6 +175,7 @@
     <Compile Include="GrainTypeManager\SiloAssemblyLoader.cs" />
     <Compile Include="GrainTypeManager\GrainTypeData.cs" />
     <Compile Include="Messaging\IncomingMessageAgent.cs" />
+    <Compile Include="Properties\orleans.codegen.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Silo\Silo.cs" />
     <Compile Include="Catalog\Catalog.cs" />
@@ -206,4 +207,25 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- Begin Orleans: Without these lines the project won't build properly -->
+  <PropertyGroup>
+    <OrleansProjectType>Server</OrleansProjectType>
+  </PropertyGroup>
+  <!-- Set path to ClientGenerator.exe -->
+  <Choose>
+    <When Condition="'$(builduri)' != ''">
+      <PropertyGroup>
+        <!-- TFS build -->
+        <OrleansReferencesBase>$(TargetDir)</OrleansReferencesBase>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <!-- Visual Studio or MsBuild .sln build -->
+        <OrleansReferencesBase>$(ProjectDir)..\ClientGenerator\$(OutputPath)</OrleansReferencesBase>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(ProjectDir)..\Orleans.SDK.targets" />
+  <!--End Orleans -->
 </Project>


### PR DESCRIPTION
Since run time codegen doesn't support internal types, we need to use compile time codegen for runtime components. This change restores it. However, looks like something got broken in the codegen logic because it is failing to process OrleansRuntime now and throws the following exception.

> Orleans-CodeGen - Generating file C:\GitHub\sergeybykov\Orleans\src\OrleansRuntime\obj\Debug\Generated\OrleansRuntime.codegen.cs
> 1>Error : Orleans code generator found error : -- Code-gen FAILED --
> 1>  Exception = System.NullReferenceException: Object reference not set to an instance of an object.
> 1>     at Microsoft.CodeAnalysis.SyntaxNodeExtensions.NormalizeWhitespace[TNode](TNode node, String indentation, Boolean elasticTrivia)
> 1>     at Orleans.CodeGenerator.CodeGeneratorCommon.GenerateSourceCode(CompilationUnitSyntax code) in c:\GitHub\sergeybykov\Orleans\src\OrleansCodeGenerator\CodeGeneratorCommon.cs:line 171
> 1>     at Orleans.CodeGenerator.CodeGenerator.GenerateSourceForAssembly(Assembly input) in c:\GitHub\sergeybykov\Orleans\src\OrleansCodeGenerator\CodeGenerator.cs:line 132
> 1>     at Orleans.CodeGeneration.GrainClientGenerator.CreateGrainClient(CodeGenOptions options) in c:\GitHub\sergeybykov\Orleans\src\ClientGenerator\ClientGenerator.cs:line 178
> 1>     at Orleans.CodeGeneration.GrainClientGenerator.CreateGrainClient(CodeGenOptions options)
> 1>     at Orleans.CodeGeneration.GrainClientGenerator.CreateGrainClientAssembly(CodeGenOptions options) in c:\GitHub\sergeybykov\Orleans\src\ClientGenerator\ClientGenerator.cs:line 125
> 1>     at Orleans.CodeGeneration.GrainClientGenerator.RunMain(String[] args) in c:\GitHub\sergeybykov\Orleans\src\ClientGenerator\ClientGenerator.cs:line 876
