### PR TITLE
Start V2 silo before setting the versioning policy

### DIFF
--- a/src/OrleansRuntime/Silo/Silo.cs
+++ b/src/OrleansRuntime/Silo/Silo.cs
@@ -591,7 +591,8 @@ namespace Orleans.Runtime
             allSiloProviders.AddRange(storageProviderManager.GetProviders());
             var versionStore = Services.GetService<IVersionStore>() as GrainVersionStore;
             versionStore?.SetStorageManager(storageProviderManager);
-            typeManager.Initialize(versionStore);
+            scheduler.QueueTask(() => this.typeManager.Initialize(versionStore), this.typeManager.SchedulingContext)
+                     .WaitWithThrow(this.initTimeout);
             if (logger.IsVerbose) { logger.Verbose("Storage provider manager created successfully."); }
 
             // Initialize log consistency providers once we have a basic silo runtime environment operating

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/RuntimeStrategyChangeTests.cs
@@ -142,10 +142,10 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
             var grainV1 = Client.GetGrain<IVersionUpgradeTestGrain>(0);
             Assert.Equal(1, await grainV1.GetVersion());
 
+            await StartSiloV2();
+
             // Change default to minimum version
             await ManagementGrain.SetSelectorStrategy(MinimumVersion.Singleton);
-
-            await StartSiloV2();
 
             // But only activate V1
             for (int i = 0; i < 100; i++)

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -182,7 +182,6 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         {
             var handle = await StartSilo(assemblyGrainsV1Dir);
             await Task.Delay(waitDelay);
-            await Task.Delay(TimeSpan.FromSeconds(90));
             return handle;
         }
 

--- a/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
+++ b/test/Tester/HeterogeneousSilosTests/UpgradeTests/UpgradeTestsBase.cs
@@ -182,6 +182,7 @@ namespace Tester.HeterogeneousSilosTests.UpgradeTests
         {
             var handle = await StartSilo(assemblyGrainsV1Dir);
             await Task.Delay(waitDelay);
+            await Task.Delay(TimeSpan.FromSeconds(90));
             return handle;
         }
 


### PR DESCRIPTION
After I made this change, the test started to pass for me locally. My suspicion is that v2 silo for some reason is slow to pick up the default selection strategy. If my fix works here, we can track down the other issue with a separate test.