### PR TITLE
Fix directory snapshot transfer ranges

### DIFF
--- a/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
+++ b/src/Orleans.Runtime/GrainDirectory/GrainDirectoryPartition.cs
@@ -329,7 +329,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         Debug.Assert(!addedRange.Intersects(removedRange));
         Debug.Assert(addedRange.IsEmpty || addedRange.Intersects(_currentRange));
         Debug.Assert(!addedRange.Intersects(previousRange));
-        Debug.Assert(previousRange.IsEmpty || _currentRange.IsEmpty || previousRange.Start == _currentRange.Start);
+        Debug.Assert(previousRange.IsEmpty || previousRange.IsFull || _currentRange.IsEmpty || _currentRange.IsFull || previousRange.Start == _currentRange.Start);
 #endif
 
         if (!removedRange.IsEmpty)
@@ -443,7 +443,7 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
                         var previousOwnerRange = previousOwnerRanges[partitionIndex];
                         if (previousOwnerRange.Intersects(addedRange))
                         {
-                            tasks.Add(TransferSnapshotAsync(current, addedRange, previousOwner, partitionIndex, previous.Version));
+                            tasks.Add(TransferSnapshotAsync(current, previousOwnerRange, addedRange, previousOwner, partitionIndex, previous.Version));
                         }
                     }
                 }
@@ -504,44 +504,53 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
         }
     }
 
-    private async Task<bool> TransferSnapshotAsync(DirectoryMembershipSnapshot current, RingRange addedRange, SiloAddress previousOwner, int partitionIndex, MembershipVersion previousVersion)
+    private async Task<bool> TransferSnapshotAsync(
+        DirectoryMembershipSnapshot current,
+        RingRange previousOwnerRange,
+        RingRange addedRange,
+        SiloAddress previousOwner,
+        int partitionIndex,
+        MembershipVersion previousVersion)
     {
         try
         {
             var stopwatch = ValueStopwatch.StartNew();
-            LogTraceRequestingEntries(_logger, addedRange, previousOwner, previousVersion);
 
             var partition = GetPartitionReference(previousOwner, partitionIndex);
             var transferredEntries = 0;
             var waitedForRange = false;
-            foreach (var queryRange in GetActivationQueryRanges(addedRange))
+            foreach (var transferRange in previousOwnerRange.Intersections(addedRange))
             {
-                // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
-                var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, queryRange).AsTask().WaitAsync(ShutdownToken);
-
-                if (snapshot is null)
+                LogTraceRequestingEntries(_logger, transferRange, previousOwner, previousVersion);
+                foreach (var queryRange in GetActivationQueryRanges(transferRange))
                 {
-                    LogWarningExpectedValidSnapshot(_logger, previousOwner, queryRange);
-                    return false;
+                    // Alternatively, the previous owner could push the snapshot. The pull-based approach is used here because it is simpler.
+                    var snapshot = await partition.GetSnapshotAsync(current.Version, previousVersion, queryRange).AsTask().WaitAsync(ShutdownToken);
+
+                    if (snapshot is null)
+                    {
+                        LogWarningExpectedValidSnapshot(_logger, previousOwner, queryRange);
+                        return false;
+                    }
+
+                    if (!waitedForRange)
+                    {
+                        // Wait for previous versions to be unlocked before proceeding.
+                        await WaitForRange(addedRange, previousVersion);
+                        waitedForRange = true;
+                    }
+
+                    // Incorporate the values into the grain directory.
+                    foreach (var entry in snapshot.GrainAddresses)
+                    {
+                        DebugAssertOwnership(current, entry.GrainId);
+
+                        LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
+                        _directory[entry.GrainId] = entry;
+                    }
+
+                    transferredEntries += snapshot.GrainAddresses.Count;
                 }
-
-                if (!waitedForRange)
-                {
-                    // Wait for previous versions to be unlocked before proceeding.
-                    await WaitForRange(addedRange, previousVersion);
-                    waitedForRange = true;
-                }
-
-                // Incorporate the values into the grain directory.
-                foreach (var entry in snapshot.GrainAddresses)
-                {
-                    DebugAssertOwnership(current, entry.GrainId);
-
-                    LogTraceReceivedEntry(_logger, entry, previousOwner, previousVersion);
-                    _directory[entry.GrainId] = entry;
-                }
-
-                transferredEntries += snapshot.GrainAddresses.Count;
             }
 
             // The acknowledgement step lets the previous owner know that the snapshot has been received so that it can proceed.
@@ -896,13 +905,13 @@ internal sealed partial class GrainDirectoryPartition : SystemTarget, IGrainDire
 
     [LoggerMessage(
         Level = LogLevel.Trace,
-        Message = "Requesting entries for ranges '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
+        Message = "Requesting entries for range '{Range}' from '{PreviousOwner}' at version '{PreviousVersion}'."
     )]
     private static partial void LogTraceRequestingEntries(ILogger logger, RingRange range, SiloAddress previousOwner, MembershipVersion previousVersion);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for part of ranges '{Range}', but found none."
+        Message = "Expected a valid snapshot from previous owner '{PreviousOwner}' for range '{Range}', but found none."
     )]
     private static partial void LogWarningExpectedValidSnapshot(ILogger logger, SiloAddress previousOwner, RingRange range);
 


### PR DESCRIPTION
Stack 1/3.\n\nThis scopes distributed grain directory snapshot pulls to the intersection between the range being acquired and the range owned by each previous owner. That avoids asking a previous owner for directory entries outside of the range it actually owned.\n\nBase: feature/directory-migration-base