### PR TITLE
Scan working set for request monitoring

### DIFF
--- a/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
+++ b/src/Orleans.Runtime/Catalog/ActivationWorkingSet.cs
@@ -38,6 +38,14 @@ namespace Orleans.Runtime
 
         public int Count => _activeCount;
 
+        internal void ForEach<TState>(Action<IActivationWorkingSetMember, bool, TState> action, TState state)
+        {
+            foreach (var pair in _members)
+            {
+                action(pair.Key, pair.Value, state);
+            }
+        }
+
         public void OnActivated(IActivationWorkingSetMember member)
         {
             Debug.Assert(member is not ICollectibleGrainContext collectible || collectible.IsValid);

--- a/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
+++ b/src/Orleans.Runtime/Catalog/IncomingRequestMonitor.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -14,58 +12,30 @@ namespace Orleans.Runtime
     /// <summary>
     /// Monitors currently-active requests and sends status notifications to callers for long-running and blocked requests.
     /// </summary>
-    internal sealed class IncomingRequestMonitor : ILifecycleParticipant<ISiloLifecycle>, IActivationWorkingSetObserver
+    internal sealed class IncomingRequestMonitor : ILifecycleParticipant<ISiloLifecycle>
     {
         private static readonly TimeSpan DefaultAnalysisPeriod = TimeSpan.FromSeconds(10);
-        private static readonly TimeSpan InactiveGrainIdleness = TimeSpan.FromMinutes(1);
         private readonly IAsyncTimer _scanPeriodTimer;
+        private readonly ActivationWorkingSet _activationWorkingSet;
         private readonly IServiceProvider _serviceProvider;
         private readonly MessageFactory _messageFactory;
         private readonly IOptionsMonitor<SiloMessagingOptions> _messagingOptions;
-        private readonly ConcurrentDictionary<ActivationData, bool> _recentlyUsedActivations = new ConcurrentDictionary<ActivationData, bool>(ReferenceEqualsComparer<ActivationData>.Default);
         private bool _enabled = true;
         private Task _runTask;
 
         public IncomingRequestMonitor(
+            ActivationWorkingSet activationWorkingSet,
             IAsyncTimerFactory asyncTimerFactory,
             IServiceProvider serviceProvider,
             MessageFactory messageFactory,
             IOptionsMonitor<SiloMessagingOptions> siloMessagingOptions)
         {
             _scanPeriodTimer = asyncTimerFactory.Create(TimeSpan.FromSeconds(1), nameof(IncomingRequestMonitor));
+            _activationWorkingSet = activationWorkingSet;
             _serviceProvider = serviceProvider;
             _messageFactory = messageFactory;
             _messagingOptions = siloMessagingOptions;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void MarkRecentlyUsed(ActivationData activation)
-        {
-            if (!_enabled)
-            {
-                return;
-            }
-            
-            _recentlyUsedActivations.TryAdd(activation, true);
-        }
-
-        public void OnActive(IActivationWorkingSetMember member)
-        {
-            if (member is ActivationData activation)
-            {
-                MarkRecentlyUsed(activation);
-            }
-        }
-
-        public void OnIdle(IActivationWorkingSetMember member)
-        {
-            if (member is ActivationData activation)
-            {
-                _recentlyUsedActivations.TryRemove(activation, out _);
-            }
-        }
-
-        public void OnEvicted(IActivationWorkingSetMember member) => OnIdle(member);
 
         void ILifecycleParticipant<ISiloLifecycle>.Participate(ISiloLifecycle lifecycle)
         {
@@ -108,7 +78,6 @@ namespace Orleans.Runtime
                         _enabled = false;
                     }
 
-                    _recentlyUsedActivations.Clear();
                     continue;
                 }
 
@@ -118,23 +87,22 @@ namespace Orleans.Runtime
                     _enabled = true;
                 }
 
-                var iteration = 0;
                 var now = DateTime.UtcNow;
-                foreach (var activationEntry in _recentlyUsedActivations)
-                {
-                    var activation = activationEntry.Key;
-                    lock (activation)
+                _activationWorkingSet.ForEach(
+                    static (member, isIdle, state) =>
                     {
-                        activation.AnalyzeWorkload(now, messageCenter, _messageFactory, options);
-                    }
+                        var (self, messageCenter, options, now) = state;
+                        if (isIdle || member is not ActivationData activation)
+                        {
+                            return;
+                        }
 
-                    // Yield execution frequently
-                    if (++iteration % 100 == 0)
-                    {
-                        await Task.Yield();
-                        now = DateTime.UtcNow;
-                    }
-                }
+                        lock (activation)
+                        {
+                            activation.AnalyzeWorkload(now, messageCenter, self._messageFactory, options);
+                        }
+                    },
+                    (this, messageCenter, options, now));
             }
         }
     }

--- a/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
+++ b/src/Orleans.Runtime/Hosting/DefaultSiloServices.cs
@@ -272,7 +272,6 @@ namespace Orleans.Hosting
             services.AddSingleton<IGrainContextAccessor, GrainContextAccessor>();
             services.AddSingleton<IncomingRequestMonitor>();
             services.AddFromExisting<ILifecycleParticipant<ISiloLifecycle>, IncomingRequestMonitor>();
-            services.AddFromExisting<IActivationWorkingSetObserver, IncomingRequestMonitor>();
             services.AddSingleton<ILocalActivationStatusChecker, Runtime.LocalActivationStatusChecker>();
 
             // Scoped to a grain activation


### PR DESCRIPTION
Stacked on `rebond/activation-working-set-memory`.

Remove `IncomingRequestMonitor` as a working-set observer and scan the existing activation working set instead of maintaining a second activation dictionary.

Validation: `dotnet build src\Orleans.Runtime\Orleans.Runtime.csproj --nologo --verbosity:minimal`